### PR TITLE
Dev to Main: Refactor script for dynamic settings, registry and oscdimg.exe fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Contributions to this project are welcome! However, please understand that I pre
 - **Create New ISO File** with [`oscdimg.exe`](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/oscdimg-command-line-options) 
 
 > [!NOTE]
-> This tool is currently in alpha (v0.0.1), and it's a work in progress. Any issues can be reported using the Issues tab.
+> This tool is currently in alpha, and it's a work in progress. Any issues can be reported using the Issues tab.
 
 ### Versions
 
-[![Latest Version](https://img.shields.io/badge/Version-0.0.1Alpha%20Latest-0078D4?style=for-the-badge&logo=github&logoColor=white)](https://github.com/memstechtips/WIMUtil/releases/tag/v0.0.1)
+[![Latest Version](https://img.shields.io/badge/Version-0.0.2Alpha%20Latest-0078D4?style=for-the-badge&logo=github&logoColor=white)](https://github.com/memstechtips/WIMUtil/releases/tag/v0.0.2)
 
 ### Support the Project
 
@@ -46,7 +46,7 @@ To use **WIMUtil**, follow these steps to launch PowerShell as an Administrator 
 3. **Paste and Run the Command**:
    - Copy the following command:
      ```powershell
-     irm "https://github.com/memstechtips/WIMUtil/raw/main/src/WIMUtil.ps1" | iex 
+     irm "https://github.com/memstechtips/WIMUtil/raw/main/src/WIMUtil.ps1" | iex
      ```
    - To paste into PowerShell, **Right-Click** or press **Ctrl + V** in the PowerShell or Terminal window. </br> This should automatically paste your copied command.
    - Press **Enter** to execute the command.

--- a/config/wimutil-settings.json
+++ b/config/wimutil-settings.json
@@ -1,0 +1,15 @@
+{
+    "main": {
+        "xamlUrl": "https://github.com/memstechtips/WIMUtil/raw/main/xaml/WIMUtilGUI.xaml",
+        "oscdimgURL": "https://github.com/memstechtips/WIMUtil/raw/main/assets/executables/oscdimg.exe",
+        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B",
+        "expectedSignDate": "2023-10-19T21:51:12"
+    },
+    "dev": {
+        "xamlUrl": "https://github.com/memstechtips/WIMUtil/raw/dev/xaml/WIMUtilGUI.xaml",
+        "oscdimgURL": "https://github.com/memstechtips/WIMUtil/raw/dev/assets/executables/oscdimg.exe",
+        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B",
+        "expectedSignDate": "2023-10-19T21:51:12"
+    },
+    "defaultBranch": "main"
+}

--- a/config/wimutil-settings.json
+++ b/config/wimutil-settings.json
@@ -2,14 +2,12 @@
     "main": {
         "xamlUrl": "https://github.com/memstechtips/WIMUtil/raw/main/xaml/WIMUtilGUI.xaml",
         "oscdimgURL": "https://github.com/memstechtips/WIMUtil/raw/main/assets/executables/oscdimg.exe",
-        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B",
-        "expectedSignDate": "2023-10-19T21:51:12"
+        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B"
     },
     "dev": {
         "xamlUrl": "https://github.com/memstechtips/WIMUtil/raw/dev/xaml/WIMUtilGUI.xaml",
         "oscdimgURL": "https://github.com/memstechtips/WIMUtil/raw/dev/assets/executables/oscdimg.exe",
-        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B",
-        "expectedSignDate": "2023-10-19T21:51:12"
+        "expectedHash": "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B"
     },
     "defaultBranch": "main"
 }

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,17 +35,13 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Capture the branch name directly from the script URL
-$currentBranch = $null
+# Parse the branch from the URL used in irm (must pass the branch explicitly in the script URL)
+$irmUrl = $($hostinvocation.InvocationName)
 
-# If streaming via irm, capture the URL used in the pipeline
-if ($input -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+if ($irmUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
-    Write-Host "Branch detected from URL: $currentBranch" -ForegroundColor Green
-}
-
-# Fallback to 'main' if branch is not detected
-if (-not $currentBranch) {
+    Write-Host "Branch detected from irm URL: $currentBranch" -ForegroundColor Green
+} else {
     Write-Host "Unable to determine branch. Defaulting to 'main'." -ForegroundColor Yellow
     $currentBranch = "main"
 }

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,10 +37,8 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Detect branch dynamically from the invocation URL
 $currentBranch = "main" # Default fallback branch
-Write-Host "DEBUG: Forced branch set to: $currentBranch" -ForegroundColor Magenta
 if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
-    Write-Host "DEBUG: Branch detected from InvocationName: $currentBranch" -ForegroundColor Magenta
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,25 +35,13 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Debugging output for branch detection
-Write-Host "Invocation Name: $($MyInvocation.InvocationName)" -ForegroundColor Yellow
-Write-Host "PSCommandPath: $($PSCommandPath)" -ForegroundColor Yellow
-
-# Extract the branch from the invocation URL or fallback to main
+# Capture the branch name directly from the script URL
 $currentBranch = $null
 
-try {
-    # Check for a remote script URL in $MyInvocation.InvocationName
-    if ($MyInvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
-        $currentBranch = $matches[1]
-    }
-
-    # If $currentBranch is still null, check the pipeline input
-    if (-not $currentBranch -and $input -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
-        $currentBranch = $matches[1]
-    }
-} catch {
-    Write-Host "Error detecting branch: $($_.Exception.Message)" -ForegroundColor Red
+# If streaming via irm, capture the URL used in the pipeline
+if ($input -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+    $currentBranch = $matches[1]
+    Write-Host "Branch detected from URL: $currentBranch" -ForegroundColor Green
 }
 
 # Fallback to 'main' if branch is not detected
@@ -62,8 +50,8 @@ if (-not $currentBranch) {
     $currentBranch = "main"
 }
 
-# Debugging output
-Write-Host "Detected Branch: $currentBranch" -ForegroundColor Green
+# Debugging output for the detected branch
+Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
 # Build the configuration URL based on the detected branch
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -44,18 +44,23 @@ function Get-LaunchBranch {
     $parentCmd = Get-WmiObject Win32_Process -Filter "ProcessId = $parentProcess" |
         Select-Object -ExpandProperty CommandLine
     
+    # Debug output to see what we're working with
+    Write-Host "Parent Command: $parentCmd" -ForegroundColor Yellow
+    
     # Check if launched via IRM and extract branch
-    if ($parentCmd -match "powershell|pwsh|WindowsTerminal" -and $parentCmd -match "irm|Invoke-RestMethod") {
-    if ($parentCmd -match "github\.com/memstechtips/WIMUtil/raw/(main|dev)/") {
-        return $matches[1]  # Returns 'main' or 'dev'
+    if ($parentCmd -match "powershell|pwsh|WindowsTerminal") {
+        if ($parentCmd -match "WIMUtil/raw/(main|dev)/") {
+            Write-Host "Branch detected from URL: $($matches[1])" -ForegroundColor Yellow
+            return $matches[1]  # Returns 'main' or 'dev'
+        }
     }
-}
     
     # If command line argument is provided
     if ($args.Count -gt 0 -and $args[0] -eq "-Branch") {
         return $args[1]
     }
     
+    Write-Host "No branch detected, defaulting to main" -ForegroundColor Yellow
     return "main"  # Default to main branch
 }
 

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,16 +37,20 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Detect branch dynamically from the invocation URL
 $currentBranch = "main" # Default fallback branch
-Write-Host "Starting branch detection..." -ForegroundColor Yellow
+Write-Host "DEBUG: Starting branch detection..." -ForegroundColor Yellow
 
 $matches = $null  # Clear previous match data
 
 try {
-    if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+    $matches = $null  # Reset matches before running the regex
+    if ($MyInvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
         $currentBranch = $matches[1]
-        Write-Host "DEBUG: Branch detected from InvocationName: $currentBranch" -ForegroundColor Green
+        Write-Host "DEBUG: Branch detected from MyInvocation.InvocationName: $currentBranch" -ForegroundColor Green
+    } elseif ($MyInvocation.Line -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+        $currentBranch = $matches[1]
+        Write-Host "DEBUG: Branch detected from MyInvocation.Line: $currentBranch" -ForegroundColor Green
     } else {
-        Write-Host "DEBUG: Unable to detect branch from InvocationName. Using fallback." -ForegroundColor Red
+        Write-Host "DEBUG: Unable to detect branch. Using fallback to 'main'." -ForegroundColor Red
     }
 } catch {
     Write-Host "DEBUG: Error during branch detection: $_" -ForegroundColor Red

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,9 +35,9 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Explicitly define the configuration URL for the branch to use
-# $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/main/config/wimutil-settings.json"  # Main branch
-$configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/dev/config/wimutil-settings.json"   # Dev branch
+# Explicitly define the configuration URL for the branch to use (commenting out the one not to use depending on branch)
+$configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/main/config/wimutil-settings.json"  # Main branch
+# $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/dev/config/wimutil-settings.json"   # Dev branch
 
 Write-Host "Using Configuration URL: $configUrl" -ForegroundColor Cyan
 

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,14 +37,12 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Function to determine which branch was used to launch the script
 function Get-LaunchBranch {
-    # Get the current process's command line
-    $currentCmd = Get-WmiObject Win32_Process -Filter "ProcessId = $PID" |
-        Select-Object -ExpandProperty CommandLine
+    Write-Host "Debug: MyInvocation Line: $($MyInvocation.Line)" -ForegroundColor Yellow
+    Write-Host "Debug: MyInvocation Command: $($MyInvocation.MyCommand)" -ForegroundColor Yellow
     
-    Write-Host "Debug: Full command: $currentCmd" -ForegroundColor Yellow
+    $commandLine = $MyInvocation.Line
     
-    # Modified pattern matching
-    if ($currentCmd -match 'WIMUtil/raw/(main|dev)/') {
+    if ($commandLine -match 'WIMUtil/raw/(main|dev)/') {
         Write-Host "Debug: URL match found" -ForegroundColor Green
         Write-Host "Debug: Branch detected: $($matches[1])" -ForegroundColor Green
         return $matches[1]

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -1,3 +1,9 @@
+# Script Parameters
+
+param (
+    [string]$Branch = "main" # Default branch is main unless overridden
+)
+
 # Check if script is running as Administrator
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")) {
     Try {
@@ -34,10 +40,6 @@ $script:currentScreenIndex = 1
 
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
-
-param (
-    [string]$Branch = "main" # Default branch is main unless overridden
-)
 
 # Write debug information about the branch
 Write-Host "DEBUG: Detected branch parameter: $Branch" -ForegroundColor Magenta

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -1,8 +1,3 @@
-$script:launchUrl = $null
-if ($MyInvocation.MyCommand.ScriptBlock.Module.SessionState.PSVariable.Get("__irm_url")) {
-    $script:launchUrl = $MyInvocation.MyCommand.ScriptBlock.Module.SessionState.PSVariable.Get("__irm_url").Value
-}
-
 # Check if script is running as Administrator
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")) {
     Try {
@@ -46,15 +41,20 @@ $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/dev/config/
 
 Write-Host "Using Configuration URL: $configUrl" -ForegroundColor Yellow
 
+# Detect branch based on the script URL
 $currentBranch = "unknown"  # Default value
+Write-Host "DEBUG: Script URL: $scriptUrl" -ForegroundColor Magenta
 
-if ($scriptUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+if ($scriptUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/src/WIMUtil.ps1") {
     $currentBranch = $matches[1]
+    Write-Host "DEBUG: Branch detected from URL: $currentBranch" -ForegroundColor Green
+} else {
+    Write-Host "DEBUG: Regex did not match. Using fallback." -ForegroundColor Yellow
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
-# Construct the configuration URL based on the detected branch
+# Construct the configuration URL
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
 Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
 
@@ -69,7 +69,6 @@ try {
 
 # Fetch settings for the current branch
 $branchConfig = $config.$currentBranch
-
 if (-not $branchConfig) {
     Write-Host "Branch $currentBranch not found in configuration file. Exiting script." -ForegroundColor Red
     exit 1

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -40,27 +40,18 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Function to determine which branch was used to launch the script
-function Get-LaunchBranch {
-    Write-Host "Debug: Launch URL: $script:launchUrl" -ForegroundColor Yellow
-    
-    # First try from stored URL
-    if ($script:launchUrl -match 'WIMUtil/raw/(main|dev)/') {
-        Write-Host "Debug: Branch detected from stored URL: $($matches[1])" -ForegroundColor Green
-        return $matches[1]
-    }
-    
-    # If command line argument is provided
-    if ($args.Count -gt 0 -and $args[0] -eq "-Branch") {
-        return $args[1]
-    }
-    
-    Write-Host "Debug: No branch detected, defaulting to main" -ForegroundColor Yellow
-    return "main"
+# Explicitly define the configuration URL for the branch to use
+# $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/main/config/wimutil-settings.json"  # Main branch
+$configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/dev/config/wimutil-settings.json"   # Dev branch
+
+Write-Host "Using Configuration URL: $configUrl" -ForegroundColor Yellow
+
+$currentBranch = "unknown"  # Default value
+
+if ($scriptUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+    $currentBranch = $matches[1]
 }
 
-# Detect branch dynamically
-$currentBranch = Get-LaunchBranch
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
 # Construct the configuration URL based on the detected branch
@@ -78,10 +69,14 @@ try {
 
 # Fetch settings for the current branch
 $branchConfig = $config.$currentBranch
+
 if (-not $branchConfig) {
     Write-Host "Branch $currentBranch not found in configuration file. Exiting script." -ForegroundColor Red
     exit 1
 }
+
+# Debugging output
+Write-Host "Branch settings loaded for: $currentBranch" -ForegroundColor Cyan
 
 # Extract configuration settings
 $xamlUrl = $branchConfig.xamlUrl

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -492,32 +492,33 @@ if ($readerOperationSuccessful) {
     }
 
     # Function to get the signing date of a file
-    function Get-SignatureDate {
-        param (
-            [string]$filePath
-        )
+function Get-SignatureDate {
+    param (
+        [string]$filePath
+    )
 
-        if (Test-Path -Path $filePath) {
-            try {
-                $signature = Get-AuthenticodeSignature -FilePath $filePath
-                if ($signature.Status -eq 'Valid') {
-                    return $signature.SignerCertificate.NotBefore
-                }
-                else {
-                    Write-Host "The file's digital signature is not valid."
-                    return $null
-                }
+    if (Test-Path -Path $filePath) {
+        try {
+            $signature = Get-AuthenticodeSignature -FilePath $filePath
+            if ($signature.Status -eq 'Valid') {
+                # Convert the signing date to UTC for comparison
+                return $signature.SignerCertificate.NotBefore.ToUniversalTime()
             }
-            catch {
-                Write-Host "Error retrieving the signature date: $_"
+            else {
+                Write-Host "The file's digital signature is not valid."
                 return $null
             }
         }
-        else {
-            Write-Host "File not found at path: $filePath"
+        catch {
+            Write-Host "Error retrieving the signature date: $_"
             return $null
         }
     }
+    else {
+        Write-Host "File not found at path: $filePath"
+        return $null
+    }
+}
 
     # Check if oscdimg exists on the system without checking hash or date
     function CheckOscdimg {
@@ -537,7 +538,7 @@ if ($readerOperationSuccessful) {
         [System.Windows.Forms.Application]::DoEvents()  # Refresh the UI
     }
 
-    # Function to download and validate oscdimg
+# Updated DownloadOscdimg Function
 function DownloadOscdimg {
     SetStatusText -message "Preparing to download oscdimg..." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
     [System.Windows.Forms.Application]::DoEvents()

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -69,10 +69,9 @@ if (-not $branchConfig) {
 $xamlUrl = $branchConfig.xamlUrl
 $oscdimgURL = $branchConfig.oscdimgURL
 $expectedHash = $branchConfig.expectedHash
-$expectedSignDate = ([datetime]$branchConfig.expectedSignDate).ToUniversalTime()
 
 # Validate that required keys are present in the configuration
-if (-not ($xamlUrl -and $oscdimgURL -and $expectedHash -and $expectedSignDate)) {
+if (-not ($xamlUrl -and $oscdimgURL -and $expectedHash)) {
     Write-Host "Configuration file is missing required settings. Exiting script." -ForegroundColor Red
     exit 1
 }

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -39,26 +39,20 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 # $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/main/config/wimutil-settings.json"  # Main branch
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/dev/config/wimutil-settings.json"   # Dev branch
 
-Write-Host "Using Configuration URL: $configUrl" -ForegroundColor Yellow
+Write-Host "Using Configuration URL: $configUrl" -ForegroundColor Cyan
 
-# Detect branch based on the script URL
-$currentBranch = "unknown"  # Default value
-Write-Host "DEBUG: Script URL: $scriptUrl" -ForegroundColor Magenta
-
-if ($scriptUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/src/WIMUtil.ps1") {
+# Determine branch from the configuration URL
+$currentBranch = "unknown"  # Fallback value
+if ($configUrl -match "https://raw.githubusercontent.com/memstechtips/WIMUtil/([^/]+)/config/wimutil-settings.json") {
     $currentBranch = $matches[1]
-    Write-Host "DEBUG: Branch detected from URL: $currentBranch" -ForegroundColor Green
+    Write-Host "Branch detected from Configuration URL: $currentBranch" -ForegroundColor Green
 } else {
-    Write-Host "DEBUG: Regex did not match. Using fallback." -ForegroundColor Yellow
+    Write-Host "Unable to detect branch from Configuration URL. Using fallback." -ForegroundColor Yellow
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
-# Construct the configuration URL
-$configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
-Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
-
-# Load the configuration from the URL
+# Load the configuration from the specified URL
 try {
     $config = (Invoke-WebRequest -Uri $configUrl -ErrorAction Stop).Content | ConvertFrom-Json
     Write-Host "Configuration loaded successfully from $configUrl" -ForegroundColor Green
@@ -74,8 +68,7 @@ if (-not $branchConfig) {
     exit 1
 }
 
-# Debugging output
-Write-Host "Branch settings loaded for: $currentBranch" -ForegroundColor Cyan
+Write-Host "Branch settings successfully loaded for: $currentBranch" -ForegroundColor Cyan
 
 # Extract configuration settings
 $xamlUrl = $branchConfig.xamlUrl

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -39,18 +39,21 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 $currentBranch = "main" # Default fallback branch
 Write-Host "Starting branch detection..." -ForegroundColor Yellow
 
+$matches = $null  # Clear previous match data
+
 try {
     if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
         $currentBranch = $matches[1]
-        Write-Host "Branch detected from InvocationName: $currentBranch" -ForegroundColor Green
+        Write-Host "DEBUG: Branch detected from InvocationName: $currentBranch" -ForegroundColor Green
     } else {
-        Write-Host "Unable to detect branch from InvocationName. Using fallback." -ForegroundColor Red
+        Write-Host "DEBUG: Unable to detect branch from InvocationName. Using fallback." -ForegroundColor Red
     }
 } catch {
-    Write-Host "Error during branch detection: $_" -ForegroundColor Red
+    Write-Host "DEBUG: Error during branch detection: $_" -ForegroundColor Red
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
+Pause
 
 # Construct the configuration URL based on the detected branch
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,20 +35,15 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Detect branch from the full URL of the invoked script
-$hostInvocationName = $hostinvocation.InvocationName
-
-if ($hostInvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+# Detect branch dynamically from the invocation URL
+$currentBranch = "main" # Default fallback branch
+if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
-    Write-Host "Branch detected from URL: $currentBranch" -ForegroundColor Green
-} else {
-    Write-Host "Unable to determine branch. Defaulting to 'main'." -ForegroundColor Yellow
-    $currentBranch = "main"
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
-# Construct configuration URL
+# Construct the configuration URL based on the detected branch
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
 Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
 
@@ -61,18 +56,10 @@ try {
     exit 1
 }
 
-
-# Fetch settings for the current branch or fallback to default
+# Fetch settings for the current branch
 $branchConfig = $config.$currentBranch
-
 if (-not $branchConfig) {
-    Write-Host "Branch $currentBranch not found in configuration file. Falling back to default branch." -ForegroundColor Yellow
-    $currentBranch = $config.defaultBranch
-    $branchConfig = $config.$currentBranch
-}
-
-if (-not $branchConfig) {
-    Write-Host "Default branch $currentBranch not found in configuration file. Exiting script." -ForegroundColor Red
+    Write-Host "Branch $currentBranch not found in configuration file. Exiting script." -ForegroundColor Red
     exit 1
 }
 

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -36,7 +36,7 @@ $script:currentScreenIndex = 1
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
 # Detect branch dynamically from the invocation URL
-$currentBranch = "dev" # Default fallback branch
+$currentBranch = "main" # Default fallback branch
 Write-Host "DEBUG: Forced branch set to: $currentBranch" -ForegroundColor Magenta
 if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,54 +35,22 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Define the URLs for dev and main branches
-$devUrl = "https://github.com/memstechtips/WIMUtil/raw/dev/src/WIMUtil.ps1"
-$mainUrl = "https://github.com/memstechtips/WIMUtil/raw/main/src/WIMUtil.ps1"
+param (
+    [string]$Branch = "main" # Default branch is main unless overridden
+)
 
-# Default to main branch
-$currentBranch = "main"
+# Write debug information about the branch
+Write-Host "DEBUG: Detected branch parameter: $Branch" -ForegroundColor Magenta
 
-# Function to check invocation URL against predefined URLs
-function DetectBranch {
-    param (
-        [string]$InvocationName
-    )
-
-    if ($InvocationName -eq $devUrl) {
-        return "dev"
-    } elseif ($InvocationName -eq $mainUrl) {
-        return "main"
-    } else {
-        return $null
-    }
-}
-
-# Attempt to detect the branch from MyInvocation
-if ($MyInvocation -and $MyInvocation.InvocationName) {
-    $currentBranch = DetectBranch -InvocationName $MyInvocation.InvocationName
-}
-
-# Fallback to HostInvocation if MyInvocation didn't detect the branch
-if (-not $currentBranch -or $currentBranch -eq $null) {
-    if ($hostinvocation -and $hostinvocation.InvocationName) {
-        $currentBranch = DetectBranch -InvocationName $hostinvocation.InvocationName
-    }
-}
-
-# If still not detected, use the default branch
-if (-not $currentBranch -or $currentBranch -eq $null) {
-    Write-Host "DEBUG: Unable to detect branch from InvocationName. Using fallback to 'main'." -ForegroundColor Yellow
-    $currentBranch = "main"
-}
-
+# Set the branch based on the -branch parameter
+$currentBranch = $Branch
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
-Pause
 
-# Construct the configuration URL based on the detected branch
-$configUrl = "https://github.com/memstechtips/WIMUtil/raw/$currentBranch/config/wimutil-settings.json"
+# Construct the configuration URL based on the branch
+$configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
 Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
 
-# Load the configuration
+# Load the configuration from the URL
 try {
     $config = (Invoke-WebRequest -Uri $configUrl -ErrorAction Stop).Content | ConvertFrom-Json
     Write-Host "Configuration loaded successfully from $configUrl" -ForegroundColor Green

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -44,15 +44,13 @@ function Get-LaunchBranch {
     $parentCmd = Get-WmiObject Win32_Process -Filter "ProcessId = $parentProcess" |
         Select-Object -ExpandProperty CommandLine
     
-    # Debug output to see what we're working with
-    Write-Host "Parent Command: $parentCmd" -ForegroundColor Yellow
+    Write-Host "Debug: Full parent command: $parentCmd" -ForegroundColor Yellow
     
-    # Check if launched via IRM and extract branch
-    if ($parentCmd -match "powershell|pwsh|WindowsTerminal") {
-        if ($parentCmd -match "WIMUtil/raw/(main|dev)/") {
-            Write-Host "Branch detected from URL: $($matches[1])" -ForegroundColor Yellow
-            return $matches[1]  # Returns 'main' or 'dev'
-        }
+    # Modified pattern matching
+    if ($parentCmd -match '"https://github\.com/memstechtips/WIMUtil/raw/(main|dev)/.+"') {
+        Write-Host "Debug: URL match found" -ForegroundColor Green
+        Write-Host "Debug: Branch detected: $($matches[1])" -ForegroundColor Green
+        return $matches[1]
     }
     
     # If command line argument is provided
@@ -60,8 +58,8 @@ function Get-LaunchBranch {
         return $args[1]
     }
     
-    Write-Host "No branch detected, defaulting to main" -ForegroundColor Yellow
-    return "main"  # Default to main branch
+    Write-Host "Debug: No branch detected, defaulting to main" -ForegroundColor Yellow
+    return "main"
 }
 
 # Detect branch dynamically

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -10,6 +10,9 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
     }
 }
 
+# Fix Internet Explorer Engine is Missing to Ensure GUI Launches
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
+
 # Load required WPF assemblies
 Add-Type -AssemblyName PresentationFramework
 Add-Type -AssemblyName System.Windows.Forms
@@ -33,28 +36,70 @@ function SetStatusText {
 
 $script:currentScreenIndex = 1
 
-# URL to the XAML file on GitHub
-$xamlUrl = "https://github.com/memstechtips/WIMUtil/raw/main/xaml/WIMUtilGUI.xaml"
+# Define the path to the configuration file
+$configFilePath = Join-Path -Path (Split-Path -Parent $MyInvocation.MyCommand.Path) -ChildPath "..\config\wimutil-settings.json"
 
-# Download and load the XAML content
+# Load the configuration
+if (Test-Path -Path $configFilePath) {
+    $config = Get-Content -Path $configFilePath | ConvertFrom-Json
+} else {
+    Write-Host "Configuration file not found: $configFilePath" -ForegroundColor Red
+    exit 1
+}
+
+# Determine the current branch
+function Get-GitBranch {
+    param (
+        [string]$repoPath = (Get-Location)  # Default to the current directory
+    )
+
+    try {
+        $headFile = Join-Path -Path $repoPath -ChildPath ".git\HEAD"
+        if (Test-Path $headFile) {
+            $headContent = Get-Content -Path $headFile
+            if ($headContent -match "refs/heads/(.+)$") {
+                return $matches[1]
+            }
+        }
+    } catch {
+        Write-Host "Error determining Git branch: $_" -ForegroundColor Red
+    }
+    return $config.defaultBranch  # Fallback to the default branch
+}
+
+# Get the current branch or default
+$currentBranch = Get-GitBranch
+
+# Fetch settings for the current branch
+if ($config.$currentBranch) {
+    $xamlUrl = $config.$currentBranch.xamlUrl
+    $oscdimgURL = $config.$currentBranch.oscdimgURL
+    $expectedHash = $config.$currentBranch.expectedHash
+    $expectedSignDate = ([datetime]$config.$currentBranch.expectedSignDate).ToUniversalTime()
+} else {
+    Write-Host "Branch $currentBranch not found in configuration file. Falling back to default branch." -ForegroundColor Yellow
+    $currentBranch = $config.defaultBranch
+    $xamlUrl = $config.$currentBranch.xamlUrl
+    $oscdimgURL = $config.$currentBranch.oscdimgURL
+    $expectedHash = $config.$currentBranch.expectedHash
+    $expectedSignDate = ([datetime]$config.$currentBranch.expectedSignDate).ToUniversalTime()
+}
+
+
+# Load XAML GUI
 try {
-    # Download XAML content as a string
+    # Load XAML from the dynamically loaded URL
     $xamlContent = (Invoke-WebRequest -Uri $xamlUrl).Content
 
     # Load the XAML using XamlReader.Load with a MemoryStream
     $encoding = [System.Text.Encoding]::UTF8
     $xamlBytes = $encoding.GetBytes($xamlContent)
     $xamlStream = [System.IO.MemoryStream]::new($xamlBytes)
-
-    # Parse the XAML content
     $window = [System.Windows.Markup.XamlReader]::Load($xamlStream)
     $readerOperationSuccessful = $true
-
-    # Clean up stream
     $xamlStream.Close()
-}
-catch {
-    Write-Host "Error loading XAML from URL: $($_.Exception.Message)" -ForegroundColor Red
+} catch {
+    Write-Host "Error loading XAML from URL: $xamlUrl" -ForegroundColor Red
     $readerOperationSuccessful = $false
 }
 
@@ -433,12 +478,6 @@ if ($readerOperationSuccessful) {
         [System.Windows.Forms.Application]::DoEvents()
     }
 
-
-    # Define expected hash and signing date of oscdimg.exe file to determine if it's been tampered with
-    # Note: Different versions of oscdimg.exe will have different hashes and signing dates
-    $expectedHash = "CACD23ABCD1E1B791F6280D7D86270FF8D4144728FF611033BAF5599D883731B"
-    $expectedSignDate = [datetime]"2023-10-19T21:51:12" 
-
     # Function to get the SHA-256 hash of a file
     function Get-FileHashValue {
         param (
@@ -502,60 +541,71 @@ if ($readerOperationSuccessful) {
     }
 
     # Function to download and validate oscdimg
-    function DownloadOscdimg {
-        SetStatusText -message "Preparing to download oscdimg..." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
-        [System.Windows.Forms.Application]::DoEvents()
+function DownloadOscdimg {
+    SetStatusText -message "Preparing to download oscdimg..." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
+    [System.Windows.Forms.Application]::DoEvents()
 
-        $oscdimgURL = "https://github.com/memstechtips/WIMUtil/raw/main/assets/executables/oscdimg.exe"
-        $adkOscdimgPath = "C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\Oscdimg"
-        $oscdimgFullPath = Join-Path -Path $adkOscdimgPath -ChildPath "oscdimg.exe"
+    $adkOscdimgPath = "C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\Oscdimg"
+    $oscdimgFullPath = Join-Path -Path $adkOscdimgPath -ChildPath "oscdimg.exe"
 
-        # Ensure the ADK directory exists
-        if (!(Test-Path -Path $adkOscdimgPath)) {
-            New-Item -ItemType Directory -Path $adkOscdimgPath -Force | Out-Null
-            SetStatusText -message "Created directory for oscdimg at: $adkOscdimgPath" -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
-            [System.Windows.Forms.Application]::DoEvents()
-        }
-
-        # Download oscdimg to the ADK path
-        try {
-            SetStatusText -message "Downloading oscdimg to $adkOscdimgPath..." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
-            [System.Windows.Forms.Application]::DoEvents()
-
-        (New-Object System.Net.WebClient).DownloadFile($oscdimgURL, $oscdimgFullPath)
-            SetStatusText -message "oscdimg downloaded successfully." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
-
-            # Verify the file's hash
-            $actualHash = Get-FileHashValue -filePath $oscdimgFullPath
-            if ($actualHash -ne $expectedHash) {
-                SetStatusText -message "Hash mismatch! oscdimg may not be from Microsoft." -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
-                Write-Host "Expected Hash: $expectedHash"
-                Write-Host "Actual Hash: $actualHash"
-                Remove-Item -Path $oscdimgFullPath -Force
-                return
-            }
-
-            # Verify the file's signature date
-            $actualSignDate = Get-SignatureDate -filePath $oscdimgFullPath
-            if ($actualSignDate -ne $expectedSignDate) {
-                SetStatusText -message "Signature date mismatch! oscdimg may not be from Microsoft." -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
-                Write-Host "Expected Sign Date: $expectedSignDate"
-                Write-Host "Actual Sign Date: $actualSignDate"
-                Remove-Item -Path $oscdimgFullPath -Force
-                return
-            }
-
-            # File is valid, enable the Create ISO button
-            SetStatusText -message "oscdimg verified and ready for use." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
-            $GetoscdimgButton.IsEnabled = $false
-            $CreateISOButton.IsEnabled = $true
-        }
-        catch {
-            SetStatusText -message "Failed to download oscdimg: $($_.Exception.Message)" -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
-        }
-
+    # Ensure the ADK directory exists
+    if (!(Test-Path -Path $adkOscdimgPath)) {
+        New-Item -ItemType Directory -Path $adkOscdimgPath -Force | Out-Null
+        SetStatusText -message "Created directory for oscdimg at: $adkOscdimgPath" -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
         [System.Windows.Forms.Application]::DoEvents()
     }
+
+    # Download oscdimg to the ADK path
+    try {
+        SetStatusText -message "Downloading oscdimg from: $oscdimgURL" -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
+        [System.Windows.Forms.Application]::DoEvents()
+
+        (New-Object System.Net.WebClient).DownloadFile($oscdimgURL, $oscdimgFullPath)
+        Write-Host "oscdimg downloaded successfully from: $oscdimgURL"
+
+        # Verify the file's hash
+        $actualHash = Get-FileHashValue -filePath $oscdimgFullPath
+        if ($actualHash -ne $expectedHash) {
+            SetStatusText -message "Hash mismatch! oscdimg may not be from Microsoft." -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
+            Write-Host "Expected Hash: $expectedHash"
+            Write-Host "Actual Hash: $actualHash"
+            Remove-Item -Path $oscdimgFullPath -Force
+            return
+        }
+
+        # Verify the file's signature date
+        $actualSignDate = Get-SignatureDate -filePath $oscdimgFullPath
+        if ($null -eq $actualSignDate) {
+            SetStatusText -message "Failed to retrieve signature date." -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
+            Remove-Item -Path $oscdimgFullPath -Force
+            return
+        }
+
+        # Safeguard: Check if system clock is correct
+        if ([datetime]::UtcNow -lt $actualSignDate) {
+            SetStatusText -message "System clock might be incorrect. The signing date is in the future!" -color $Script:WarningColor -textBlock ([ref]$CreateISOStatusText)
+            Write-Host "Warning: The system clock may be incorrect. Signing date is in the future!"
+        }
+
+        # Compare signing date
+        if ($actualSignDate -ne $expectedSignDate) {
+            SetStatusText -message "Signature date mismatch! oscdimg may not be from Microsoft." -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
+            Write-Host "Expected Sign Date (UTC): $expectedSignDate"
+            Write-Host "Actual Sign Date (UTC): $actualSignDate"
+            Remove-Item -Path $oscdimgFullPath -Force
+            return
+        }
+
+        # File is valid, enable the Create ISO button
+        SetStatusText -message "oscdimg verified and ready for use." -color $Script:SuccessColor -textBlock ([ref]$CreateISOStatusText)
+        $GetoscdimgButton.IsEnabled = $false
+        $CreateISOButton.IsEnabled = $true
+    } catch {
+        SetStatusText -message "Failed to download oscdimg: $($_.Exception.Message)" -color $Script:ErrorColor -textBlock ([ref]$CreateISOStatusText)
+    }
+
+    [System.Windows.Forms.Application]::DoEvents()
+}
 
     # Define the location selection function
     function SelectNewISOLocation {
@@ -618,7 +668,6 @@ if ($readerOperationSuccessful) {
     $GetoscdimgButton.Add_Click({ DownloadOscdimg })
     $SelectISOLocationButton.Add_Click({ SelectNewISOLocation })
     $CreateISOButton.Add_Click({ CreateISO })
-
 
     # Event handler for the Next button
     # Next button to navigate to the next screen

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -1,3 +1,8 @@
+$script:launchUrl = $null
+if ($MyInvocation.MyCommand.ScriptBlock.Module.SessionState.PSVariable.Get("__irm_url")) {
+    $script:launchUrl = $MyInvocation.MyCommand.ScriptBlock.Module.SessionState.PSVariable.Get("__irm_url").Value
+}
+
 # Check if script is running as Administrator
 If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")) {
     Try {
@@ -37,14 +42,11 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Function to determine which branch was used to launch the script
 function Get-LaunchBranch {
-    Write-Host "Debug: MyInvocation Line: $($MyInvocation.Line)" -ForegroundColor Yellow
-    Write-Host "Debug: MyInvocation Command: $($MyInvocation.MyCommand)" -ForegroundColor Yellow
+    Write-Host "Debug: Launch URL: $script:launchUrl" -ForegroundColor Yellow
     
-    $commandLine = $MyInvocation.Line
-    
-    if ($commandLine -match 'WIMUtil/raw/(main|dev)/') {
-        Write-Host "Debug: URL match found" -ForegroundColor Green
-        Write-Host "Debug: Branch detected: $($matches[1])" -ForegroundColor Green
+    # First try from stored URL
+    if ($script:launchUrl -match 'WIMUtil/raw/(main|dev)/') {
+        Write-Host "Debug: Branch detected from stored URL: $($matches[1])" -ForegroundColor Green
         return $matches[1]
     }
     

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -1,5 +1,4 @@
 # Script Parameters
-
 param (
     [string]$Branch = "main" # Default branch is main unless overridden
 )
@@ -41,11 +40,16 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Write debug information about the branch
-Write-Host "DEBUG: Detected branch parameter: $Branch" -ForegroundColor Magenta
+# Detect branch dynamically or through parameters
+$currentBranch = "main" # Default branch is main
 
-# Set the branch based on the -branch parameter
-$currentBranch = $Branch
+# Check if script is run directly with a parameter
+if ($PSBoundParameters.ContainsKey("Branch")) {
+    $currentBranch = $Branch
+} elseif ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+    $currentBranch = $matches[1]
+}
+
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
 # Construct the configuration URL based on the branch
@@ -60,6 +64,7 @@ try {
     Write-Host "Failed to load configuration from URL: $configUrl" -ForegroundColor Red
     exit 1
 }
+
 
 # Fetch settings for the current branch
 $branchConfig = $config.$currentBranch

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,17 +37,14 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Function to determine which branch was used to launch the script
 function Get-LaunchBranch {
-    $currentPID = $PID
-    $parentProcess = Get-WmiObject Win32_Process -Filter "ProcessId = $currentPID" | 
-        Select-Object -ExpandProperty ParentProcessId
-    
-    $parentCmd = Get-WmiObject Win32_Process -Filter "ProcessId = $parentProcess" |
+    # Get the current process's command line
+    $currentCmd = Get-WmiObject Win32_Process -Filter "ProcessId = $PID" |
         Select-Object -ExpandProperty CommandLine
     
-    Write-Host "Debug: Full parent command: $parentCmd" -ForegroundColor Yellow
+    Write-Host "Debug: Full command: $currentCmd" -ForegroundColor Yellow
     
     # Modified pattern matching
-    if ($parentCmd -match '"https://github\.com/memstechtips/WIMUtil/raw/(main|dev)/.+"') {
+    if ($currentCmd -match 'WIMUtil/raw/(main|dev)/') {
         Write-Host "Debug: URL match found" -ForegroundColor Green
         Write-Host "Debug: Branch detected: $($matches[1])" -ForegroundColor Green
         return $matches[1]

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,8 +37,10 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Detect branch dynamically from the invocation URL
 $currentBranch = "dev" # Default fallback branch
+Write-Host "DEBUG: Forced branch set to: $currentBranch" -ForegroundColor Magenta
 if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
+    Write-Host "DEBUG: Branch detected from InvocationName: $currentBranch" -ForegroundColor Magenta
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,10 +35,10 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Detect branch based on runtime URL (hardcoded fallback)
-$currentBranch = if ("https://github.com/memstechtips/WIMUtil/raw/dev" -in $MyInvocation.InvocationName) {
+# Hardcode branch detection based on the known invocation context
+$currentBranch = if ("https://github.com/memstechtips/WIMUtil/raw/dev" -in $hostinvocation.InvocationName) {
     "dev"
-} elseif ("https://github.com/memstechtips/WIMUtil/raw/main" -in $MyInvocation.InvocationName) {
+} elseif ("https://github.com/memstechtips/WIMUtil/raw/main" -in $hostinvocation.InvocationName) {
     "main"
 } else {
     "main"  # Default to main if branch cannot be inferred
@@ -50,7 +50,7 @@ Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
 Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
 
-# Load the configuration from the URL
+# Load the configuration
 try {
     $config = (Invoke-WebRequest -Uri $configUrl -ErrorAction Stop).Content | ConvertFrom-Json
     Write-Host "Configuration loaded successfully from $configUrl" -ForegroundColor Green

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -35,18 +35,15 @@ $script:currentScreenIndex = 1
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Parse the branch from the URL used in irm (must pass the branch explicitly in the script URL)
-$irmUrl = $($hostinvocation.InvocationName)
-
-if ($irmUrl -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
-    $currentBranch = $matches[1]
-    Write-Host "Branch detected from irm URL: $currentBranch" -ForegroundColor Green
+# Detect branch based on runtime URL (hardcoded fallback)
+$currentBranch = if ("https://github.com/memstechtips/WIMUtil/raw/dev" -in $MyInvocation.InvocationName) {
+    "dev"
+} elseif ("https://github.com/memstechtips/WIMUtil/raw/main" -in $MyInvocation.InvocationName) {
+    "main"
 } else {
-    Write-Host "Unable to determine branch. Defaulting to 'main'." -ForegroundColor Yellow
-    $currentBranch = "main"
+    "main"  # Default to main if branch cannot be inferred
 }
 
-# Debugging output for the detected branch
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan
 
 # Build the configuration URL based on the detected branch

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -12,35 +12,18 @@ If (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 # Fix Internet Explorer Engine is Missing to Ensure GUI Launches
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
-# Load required WPF assemblies
-Add-Type -AssemblyName PresentationFramework
-Add-Type -AssemblyName System.Windows.Forms
-
-# Define global variables
-# Text Colors
-$Script:NeutralColor = "White"
-$Script:SuccessColor = "Green"
-$Script:ErrorColor = "Red"
-
-# Define the helper functions
-function SetStatusText {
-    param (
-        [string]$message,
-        [string]$color,
-        [ref]$textBlock
-    )
-    $textBlock.Value.Text = $message
-    $textBlock.Value.Foreground = $color
-}
-
-$script:currentScreenIndex = 1
+# Debugging output for branch detection
+Write-Host "Invocation Name: $($MyInvocation.InvocationName)" -ForegroundColor Yellow
+Write-Host "PSCommandPath: $($PSCommandPath)" -ForegroundColor Yellow
 
 # Extract the branch from the invocation URL
 $currentBranch = $null
 if ($MyInvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
+    Write-Host "Branch detected from InvocationName: $currentBranch" -ForegroundColor Green
 } elseif ($PSCommandPath -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
+    Write-Host "Branch detected from PSCommandPath: $currentBranch" -ForegroundColor Green
 }
 
 # Fallback if branch is not detected
@@ -51,6 +34,7 @@ if (-not $currentBranch) {
 
 # Build the configuration URL based on the detected branch
 $configUrl = "https://raw.githubusercontent.com/memstechtips/WIMUtil/$currentBranch/config/wimutil-settings.json"
+Write-Host "Constructed Configuration URL: $configUrl" -ForegroundColor Yellow
 
 # Load the configuration from the URL
 try {
@@ -60,6 +44,7 @@ try {
     Write-Host "Failed to load configuration from URL: $configUrl" -ForegroundColor Red
     exit 1
 }
+
 
 # Fetch settings for the current branch or fallback to default
 $branchConfig = $config.$currentBranch

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -37,8 +37,17 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "
 
 # Detect branch dynamically from the invocation URL
 $currentBranch = "main" # Default fallback branch
-if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
-    $currentBranch = $matches[1]
+Write-Host "Starting branch detection..." -ForegroundColor Yellow
+
+try {
+    if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
+        $currentBranch = $matches[1]
+        Write-Host "Branch detected from InvocationName: $currentBranch" -ForegroundColor Green
+    } else {
+        Write-Host "Unable to detect branch from InvocationName. Using fallback." -ForegroundColor Red
+    }
+} catch {
+    Write-Host "Error during branch detection: $_" -ForegroundColor Red
 }
 
 Write-Host "Using branch: $currentBranch" -ForegroundColor Cyan

--- a/src/WIMUtil.ps1
+++ b/src/WIMUtil.ps1
@@ -36,7 +36,7 @@ $script:currentScreenIndex = 1
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 2 -Force
 
 # Detect branch dynamically from the invocation URL
-$currentBranch = "main" # Default fallback branch
+$currentBranch = "dev" # Default fallback branch
 if ($hostinvocation.InvocationName -match "https://github.com/memstechtips/WIMUtil/raw/([^/]+)/") {
     $currentBranch = $matches[1]
 }


### PR DESCRIPTION
Refactor script for dynamic settings and registry fix

- Created `wimutil-settings.json` to store config for the project.
- Added dynamic loading of settings from wimutil-settings.json.
- Integrated branch-based configuration with fallback to default branch.
- Removed oscdimg.exe signing date function and only check hash value.
- Fixed GUI loading issue by setting the Internet Explorer "DisableFirstRunCustomize" registry entry at script start.
- Added configurl for `main` and `dev` branches and comment out the one not being used. (needs more work)
- Detect branch from configurl rather than scripturl 
- Update README with new latest version
- Removed " " white space in launch command.