### PR TITLE
Add RunWIMUtil.cmd Script to Simplify WIMUtil Execution

### DIFF
--- a/RunWIMUtil.cmd
+++ b/RunWIMUtil.cmd
@@ -1,0 +1,60 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+:: RunWIMUtil.cmd
+:: Author: ZeroDot1 (https://github.com/ZeroDot1)
+:: Purpose: Runs WIMUtil PowerShell script from https://github.com/memstechtips/WIMUtil
+:: Created: May 12, 2025
+
+:: Check if running as Administrator
+echo Checking for administrator privileges...
+net session >nul 2>&1
+if %errorLevel% neq 0 (
+    echo This script must be run as Administrator.
+    echo Right-click the script and select "Run as administrator".
+    pause
+    exit /b 1
+)
+
+:: Verify PowerShell is available
+echo Checking for PowerShell...
+powershell -Command "Get-Host" >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Error: PowerShell is not installed or not accessible.
+    pause
+    exit /b 1
+)
+
+:: Set PowerShell execution policy to Unrestricted
+echo Setting PowerShell execution policy to Unrestricted...
+powershell -Command "Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy Unrestricted -Force" >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Error: Failed to set PowerShell execution policy.
+    pause
+    exit /b 1
+)
+
+:: Display WIMUtil version (latest release from GitHub)
+echo Retrieving WIMUtil version...
+for /f "tokens=2 delims=:" %%a in ('curl -s https://api.github.com/repos/memstechtips/WIMUtil/releases/latest ^| find "tag_name"') do (
+    set "WIMUTIL_VERSION=%%a"
+    set "WIMUTIL_VERSION=!WIMUTIL_VERSION:~2,-2!"
+)
+if "!WIMUTIL_VERSION!"=="" (
+    echo Warning: Could not retrieve WIMUtil version. Check internet connection or GitHub API access.
+) else (
+    echo WIMUtil Version: !WIMUTIL_VERSION!
+)
+
+:: Run WIMUtil PowerShell script
+echo Launching WIMUtil...
+powershell -NoProfile -Command "irm 'https://github.com/memstechtips/WIMUtil/raw/main/src/WIMUtil.ps1' | iex"
+if %errorLevel% neq 0 (
+    echo Error: Failed to run WIMUtil. Check internet connection or GitHub repository.
+    pause
+    exit /b 1
+)
+
+echo WIMUtil execution completed. Follow the wizard instructions in the PowerShell window.
+pause
+exit /b 0


### PR DESCRIPTION
This pull request introduces RunWIMUtil.cmd, a Windows Command Prompt (CMD) script designed to streamline the execution of the WIMUtil PowerShell utility (https://github.com/memstechtips/WIMUtil). The script automates the process of running WIMUtil, ensuring proper setup with administrator privileges, PowerShell execution policy configuration, and version verification. It enhances user experience by providing a simple, double-clickable solution for launching WIMUtil on Windows 11 systems.